### PR TITLE
Remove removequotes option

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function create (config = {}) {
       if (!message.content.indexOf(prefix) && message.channel.type !== 'dm') {
         // Parse the name and input
         const raw = message.content.slice(prefix.length)
-        const args = spawnargs(raw, { removequotes: 'always' })
+        const args = spawnargs(raw)
         const command = args.shift()
 
         // Run it, if it is valid


### PR DESCRIPTION
Causes commands that have quotes in args to break, ex. code evaluation.
