### PR TITLE
Update command parsing to use minimist for input.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function create (config = {}) {
         // Parse the name and input
         const raw = message.content.slice(prefix.length)
         const input = spawnargs(raw)
-        const flags = minimist(args)
+        const flags = minimist(input)
         const args = flags._
         const command = args.shift()
 

--- a/index.js
+++ b/index.js
@@ -45,12 +45,14 @@ function create (config = {}) {
       if (!message.content.indexOf(prefix) && message.channel.type !== 'dm') {
         // Parse the name and input
         const raw = message.content.slice(prefix.length)
-        const args = spawnargs(raw)
+        const input = spawnargs(raw)
+        const flags = minimist(args)
+        const args = flags._
         const command = args.shift()
 
         // Run it, if it is valid
         if (commands.has(command)) {
-          commands.get(command)(message, args, minimist(args))
+          commands.get(command)(message, args, flags)
         }
       }
     })


### PR DESCRIPTION
This was causing bugs.  For example:

```
!color #FFF --background red
```

Your data would be:

```
args: [ '#FFF', '--background', 'red' ]
flags: { background: 'red' }
```

However, it is more expected:

```
args: [ '#FFF' ]
flags: { background: 'red' }
```

This is a fix.
