### PR TITLE
Add support for singular strings in `"plugins"`

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function create (config = {}) {
 
   let pluginPaths = config.plugins || []
   if (!Array.isArray(pluginPaths)) pluginPaths = [pluginPaths]
-   
+
   // Where `.cordlrrc` is, otherwise where you ran `cordlr`
   const base = config.config ? path.dirname(config.config) : process.cwd()
   const resolveOpts = { basedir: base }

--- a/index.js
+++ b/index.js
@@ -7,9 +7,11 @@ const resolve = require('resolve')
 
 function create (config = {}) {
   const bot = new DiscordClient(config.client)
-  const pluginPaths = config.plugins || []
   const prefix = config.prefix
 
+  let pluginPaths = config.plugins || []
+  if (!Array.isArray(pluginPaths)) pluginPaths = [pluginPaths]
+   
   // Where `.cordlrrc` is, otherwise where you ran `cordlr`
   const base = config.config ? path.dirname(config.config) : process.cwd()
   const resolveOpts = { basedir: base }


### PR DESCRIPTION
For example:

``` js
"plugins": "./suite"
```

I think this is valid, because `./suite.js` could be something like:

``` js
module.exports = [
  require('cordlr-help'),
  require('cordlr-role'),
  require('./custom'),
  function plugin () {
    // ...
  }
]
```
