### PR TITLE
Make loader shorthand handler optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function cordlr (config = {}) {
 
   // Load bot
   const loader = require(resolve.sync(config.loader, { basedir: process.cwd() }))
-  bot.on('ready', loader(bot, config))
+  const handler = loader(bot, config)
+  if (handler) bot.on('ready', handler)
   return bot
 }


### PR DESCRIPTION
Something I noticed right after we merge.

This is okay usage, but it doesn't line up with the documentation, so we should make it optional.
