### PR TITLE
Republished Cordlr-CLI and renamed variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install -g cordlr-cli
 ```
 (Requires Node v6 or greater.)
 
-Install experimental releases with `cordlr@next`.
+Install experimental releases with `cordlr-cli@next`.
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A discord bot using plugins created by the community.",
   "version": "0.2.0",
   "license": "GPL-3.0",
-  "repository": "devcord/cordlr",
+  "repository": "devcord/cordlr-cli",
   "main": "./bin/methods/start.js",
   "bin": "./bin/cordlr",
   "dependencies": {
@@ -37,7 +37,7 @@
     "easy"
   ],
   "bugs": {
-    "url": "https://github.com/Devcord/cordlr/issues"
+    "url": "https://github.com/Devcord/cordlr-cli/issues"
   },
-  "homepage": "https://github.com/Devcord/cordlr#readme"
+  "homepage": "https://github.com/Devcord/cordlr-cli#readme"
 }


### PR DESCRIPTION
Renamed `cordlr` to `cordlr-cli` and published to npmjs with version 0.2.0

Closes #91 #103