### PR TITLE
support loading token from environment variable

### DIFF
--- a/bin/methods/start.js
+++ b/bin/methods/start.js
@@ -16,7 +16,10 @@ module.exports = class Cordlr {
     }
 
     // If Token doesn't exist, return error
-    if (!this.config.token) return console.log('No token specified')
+    if (!this.config.token) {
+      if (process.env.CORDLR_TOKEN) this.config.token = process.env.CORDLR_TOKEN
+      else return console.log('No token specified')
+    }
 
     // Set default values if empty
     if (!this.config.loader) this.config.loader = this.flags.loader || 'cordlr-loader'


### PR DESCRIPTION
I'd like to be able to set the `token` via an environment variable on my server so that I don't have to commit the token into my source code (which I plan to host publicly on Github). This PR should make that possible assuming:

* The user does not specify the token in their `cordlr.json`
* The user adds their token to an environment variable named `CORDLR_TOKEN`