### PR TITLE
add start script to devserver/package.json

### DIFF
--- a/devserver/package.json
+++ b/devserver/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "../bin/cordlr start",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
Make it so people without VSCode can just change into *devserver* folder and run `npm start` / `yarn start`!